### PR TITLE
move INotifyPropertyChanged to Command class

### DIFF
--- a/Commands/AudioCommand.cs
+++ b/Commands/AudioCommand.cs
@@ -1,28 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class AudioCommand : Command, INotifyPropertyChanged
+    public class AudioCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
-
         #region Enums
 
         public enum State
@@ -54,7 +35,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _audioState)
                 {
                     _audioState = value;
-                    OnPropertyChanged("audioState");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -68,7 +49,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _monitoringType)
                 {
                     _monitoringType = value;
-                    OnPropertyChanged("monitoringType");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -82,7 +63,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sourceName)
                 {
                     _sourceName = value;
-                    OnPropertyChanged("sourceName");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -96,7 +77,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _volume)
                 {
                     _volume = value;
-                    OnPropertyChanged("volume");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -110,7 +91,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _delay)
                 {
                     _delay = value;
-                    OnPropertyChanged("delay");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -135,15 +116,15 @@ namespace NOOBS_CMDR.Commands
             switch (audioState)
             {
                 case (State.mute):
-                    return string.Format(@"/mute=""{0}""", sourceName);
+                    return $@"/mute=""{sourceName}""";
                 case (State.unmute):
-                    return string.Format(@"/unmute=""{0}""", sourceName);
+                    return $@"/unmute=""{sourceName}""";
                 case (State.toggle):
-                    return string.Format(@"/toggleaudio=""{0}""", sourceName);
+                    return $@"/toggleaudio=""{sourceName}""";
                 case (State.setVolume):
-                    return string.Format(@"/setvolume=""{0}"",{1},{2}", sourceName, volume, delay);
+                    return $@"/setvolume=""{sourceName}"",{volume},{delay}";
                 case (State.setMonitoringType):
-                    return string.Format(@"/command=SetAudioMonitorType,sourceName=""{0}"",monitorType={1}", sourceName, monitoringType);
+                    return $@"/command=SetAudioMonitorType,sourceName=""{sourceName}"",monitorType={monitoringType}";
                 default:
                     return @"";
             }

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -1,14 +1,10 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 
 namespace NOOBS_CMDR.Commands
 {
-    public abstract class Command
+    public abstract class Command : INotifyPropertyChanged
     {
 
         #region Member Variables
@@ -32,6 +28,16 @@ namespace NOOBS_CMDR.Commands
 
         #endregion Functions
 
+        #region INotifyPropertyChanged
+        
+        public event PropertyChangedEventHandler PropertyChanged;
+        
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+        
+        #endregion INotifyPropertyChanged
     }
 
 }

--- a/Commands/CommandType.cs
+++ b/Commands/CommandType.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace NOOBS_CMDR.Commands
+﻿namespace NOOBS_CMDR.Commands
 {
     public class CommandType
     {

--- a/Commands/CustomCommand.cs
+++ b/Commands/CustomCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class CustomCommand : Command, INotifyPropertyChanged
+    public class CustomCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Properties
 
@@ -33,7 +16,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _command)
                 {
                     _command = value;
-                    OnPropertyChanged("command");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/DelayCommand.cs
+++ b/Commands/DelayCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class DelayCommand : Command, INotifyPropertyChanged
+    public class DelayCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Properties
 
@@ -33,7 +16,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _delay)
                 {
                     _delay = value;
-                    OnPropertyChanged("delay");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/FilterCommand.cs
+++ b/Commands/FilterCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class FilterCommand : Command, INotifyPropertyChanged
+    public class FilterCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Enums
 
@@ -39,7 +22,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _filterState)
                 {
                     _filterState = value;
-                    OnPropertyChanged("filterState");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -53,7 +36,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sourceName)
                 {
                     _sourceName = value;
-                    OnPropertyChanged("sourceName");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -67,7 +50,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _filterName)
                 {
                     _filterName = value;
-                    OnPropertyChanged("filterName");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/ProfileCommand.cs
+++ b/Commands/ProfileCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class ProfileCommand : Command, INotifyPropertyChanged
+    public class ProfileCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Properties
 
@@ -33,7 +16,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _profileName)
                 {
                     _profileName = value;
-                    OnPropertyChanged("profileName");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/ProjectorCommand.cs
+++ b/Commands/ProjectorCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class ProjectorCommand : Command, INotifyPropertyChanged
+    public class ProjectorCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Enums
 
@@ -46,7 +29,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _projectorType)
                 {
                     _projectorType = value;
-                    OnPropertyChanged("projectorType");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -60,7 +43,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _isFullscreen)
                 {
                     _isFullscreen = value;
-                    OnPropertyChanged("isFullscreen");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -74,7 +57,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _monitor)
                 {
                     _monitor = value;
-                    OnPropertyChanged("monitor");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -88,7 +71,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sceneName)
                 {
                     _sceneName = value;
-                    OnPropertyChanged("sceneName");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -102,7 +85,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sourceName)
                 {
                     _sourceName = value;
-                    OnPropertyChanged("sourceName");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/RecordingCommand.cs
+++ b/Commands/RecordingCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class RecordingCommand : Command, INotifyPropertyChanged
+    public class RecordingCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Enums
 
@@ -46,7 +29,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _recordingStatus)
                 {
                     _recordingStatus = value;
-                    OnPropertyChanged("recordingStatus");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/ReplayBufferCommand.cs
+++ b/Commands/ReplayBufferCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class ReplayBufferCommand : Command, INotifyPropertyChanged
+    public class ReplayBufferCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Enums
 
@@ -45,7 +28,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _replayBufferState)
                 {
                     _replayBufferState = value;
-                    OnPropertyChanged("replayBufferState");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/SceneCommand.cs
+++ b/Commands/SceneCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class SceneCommand : Command, INotifyPropertyChanged
+    public class SceneCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Properties
 
@@ -33,7 +16,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sceneName)
                 {
                     _sceneName = value;
-                    OnPropertyChanged("sceneName");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/ScreenshotCommand.cs
+++ b/Commands/ScreenshotCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class ScreenshotCommand : Command, INotifyPropertyChanged
+    public class ScreenshotCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Enums
 
@@ -43,7 +26,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _screenshotType)
                 {
                     _screenshotType = value;
-                    OnPropertyChanged("screenshotType");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -57,7 +40,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sceneName)
                 {
                     _sceneName = value;
-                    OnPropertyChanged("sceneName");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -71,7 +54,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sourceName)
                 {
                     _sourceName = value;
-                    OnPropertyChanged("sourceName");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -85,7 +68,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _saveToFilePath)
                 {
                     _saveToFilePath = value;
-                    OnPropertyChanged("saveToFilePath");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/SourceCommand.cs
+++ b/Commands/SourceCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class SourceCommand : Command, INotifyPropertyChanged
+    public class SourceCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Enums
 
@@ -44,7 +27,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sourceState)
                 {
                     _sourceState = value;
-                    OnPropertyChanged("sourceState");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -58,7 +41,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sceneName)
                 {
                     _sceneName = value;
-                    OnPropertyChanged("sceneName");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -72,7 +55,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sourceName)
                 {
                     _sourceName = value;
-                    OnPropertyChanged("sourceName");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/StreamCommand.cs
+++ b/Commands/StreamCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class StreamCommand : Command, INotifyPropertyChanged
+    public class StreamCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Enums
 
@@ -44,7 +27,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _streamingStatus)
                 {
                     _streamingStatus = value;
-                    OnPropertyChanged("streamingStatus");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/StudioModeCommand.cs
+++ b/Commands/StudioModeCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class StudioModeCommand : Command, INotifyPropertyChanged
+    public class StudioModeCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Enums
 
@@ -44,7 +27,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _studioModeState)
                 {
                     _studioModeState = value;
-                    OnPropertyChanged("studioModeState");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Commands/TransitionCommand.cs
+++ b/Commands/TransitionCommand.cs
@@ -1,26 +1,9 @@
 ﻿using OBSWebsocketDotNet;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NOOBS_CMDR.Commands
 {
-    public class TransitionCommand : Command, INotifyPropertyChanged
+    public class TransitionCommand : Command
     {
-
-        #region INotifyPropertyChanged
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged
 
         #region Enums
 
@@ -45,7 +28,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _transitionState)
                 {
                     _transitionState = value;
-                    OnPropertyChanged("transitionState");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -59,7 +42,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _duration)
                 {
                     _duration = value;
-                    OnPropertyChanged("duration");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -73,7 +56,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _transitionName)
                 {
                     _transitionName = value;
-                    OnPropertyChanged("transitionName");
+                    OnPropertyChanged();
                 }
             }
         }
@@ -87,7 +70,7 @@ namespace NOOBS_CMDR.Commands
                 if (value != _sceneName)
                 {
                     _sceneName = value;
-                    OnPropertyChanged("sceneName");
+                    OnPropertyChanged();
                 }
             }
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Security;
 using System.Text.RegularExpressions;
 using System.Windows;
@@ -29,7 +30,7 @@ namespace NOOBS_CMDR
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        protected void OnPropertyChanged(string propertyName)
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
@@ -60,7 +61,7 @@ namespace NOOBS_CMDR
                 if (value != _obs)
                 {
                     _obs = value;
-                    OnPropertyChanged("obs");
+                    OnPropertyChanged();
                 }
             }
         }


### PR DESCRIPTION
I hate duplicate code so I could not resist making a pull request for this one.
Also used the CallerMemberName attribute to prevent wrong change events fired
