### PR TITLE
Added confirmation dialog if testing StreamCommand

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -402,7 +402,14 @@ namespace NOOBS_CMDR
                 MessageBox.Show(@"Please restart in admin mode to install OBSCommand.", "OBSCommand Not Installed", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
-            
+
+            if (commandList.OfType<StreamCommand>().Count() > 0)
+            {
+                var result = MessageBox.Show("You are about to execute a command that starts or stops your stream. Are you sure you want to continue?", "Potentially Risky Command", MessageBoxButton.YesNo, MessageBoxImage.Question);
+                if (result == MessageBoxResult.No)
+                    return;
+            }
+
             string strCmdText;
             strCmdText = string.Format(@"/server={0}:{1} /password=""{2}""", ServerText.Text, PortText.Text, PasswordText.Password);
 


### PR DESCRIPTION
Added a confirmation dialog that pops up if you are testing a single command or series of commands that contain a StreamCommand action. 

Damn it @nuttylmao I can't tell you how many times I've accidentally started or stopped my stream whilst playing with this app. As an aside, OBSCommand doesn't care one-tiny-bit if you have the "Show confirmation dialog when starting streams" settings checked.